### PR TITLE
Fix Program State Machine initial state

### DIFF
--- a/src/pages/programs/[id].vue
+++ b/src/pages/programs/[id].vue
@@ -167,6 +167,8 @@ export default defineComponent({
       send({
         type: program.programState,
       })
+    }, {
+      immediate: true,
     })
 
     const actions = computed(() => {


### PR DESCRIPTION
The initial state of the machine was not directly set as the watcher was called only after the first cache refresh.