### PR TITLE
Create an API layer and use type guards to verify API responses

### DIFF
--- a/src/api/program.ts
+++ b/src/api/program.ts
@@ -1,12 +1,32 @@
 import { fetcher } from './index'
-import { isGetAllProgramsResponse, isStartProgramResponse, Program } from '/~/types/index'
+import { isStartProgramResponse, isStopProgramResponse, isRestartProgramResponse } from '/~/types/index'
 
 export async function startProgram(programId: string): Promise<void> {
   const { data } = await fetcher.post('/start', {
-    program_json: programId,
+    program_id: programId,
   })
   if (!isStartProgramResponse(data))
     throw new Error('Received invalid response for POST /start endpoint')
   if (data.error !== undefined)
     throw new Error(`Received error for POST /start endpoint: ${data.error}`)
+}
+
+export async function stopProgram(programId: string): Promise<void> {
+  const { data } = await fetcher.post('/stop', {
+    program_id: programId,
+  })
+  if (!isStopProgramResponse(data))
+    throw new Error('Received invalid response for POST /stop endpoint')
+  if (data.error !== undefined)
+    throw new Error(`Received error for POST /stop endpoint: ${data.error}`)
+}
+
+export async function restartProgram(programId: string): Promise<void> {
+  const { data } = await fetcher.post('/restart', {
+    program_id: programId,
+  })
+  if (!isRestartProgramResponse(data))
+    throw new Error('Received invalid response for POST /restart endpoint')
+  if (data.error !== undefined)
+    throw new Error(`Received error for POST /restart endpoint: ${data.error}`)
 }

--- a/src/machines/program.ts
+++ b/src/machines/program.ts
@@ -1,4 +1,4 @@
-import { createMachine } from 'xstate'
+import { Machine } from 'xstate'
 
 import { ProgramState } from '/~/types/index'
 
@@ -22,51 +22,18 @@ export interface ProgramMachineMeta {
 
 interface ProgramMachineContext {}
 
-type ProgramMachineState =
-  | {
-    value: 'SELECTING'
-    context: ProgramMachineContext
+interface ProgramMachineState {
+  states: {
+    [ProgramState.STARTING]: {}
+    [ProgramState.RUNNING]: {}
+    [ProgramState.STOPPING]: {}
+    [ProgramState.STOPPED]: {}
+    [ProgramState.BACKOFF]: {}
+    [ProgramState.EXITED]: {}
+    [ProgramState.FATAL]: {}
+    [ProgramState.UNKNOWN]: {}
   }
-  | {
-    value: ProgramState.STARTING
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
-  | {
-    value: ProgramState.RUNNING
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
-  | {
-    value: ProgramState.STOPPING
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
-  | {
-    value: ProgramState.STOPPED
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
-  | {
-    value: ProgramState.BACKOFF
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
-  | {
-    value: ProgramState.EXITED
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
-  | {
-    value: ProgramState.FATAL
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
-  | {
-    value: ProgramState.UNKNOWN
-    context: ProgramMachineContext
-    meta: ProgramMachineMeta
-  }
+}
 
 type ProgramMachineEvent =
   | {
@@ -85,7 +52,7 @@ type ProgramMachineEvent =
     type: ProgramState
   }
 
-export const programMachine = createMachine<ProgramMachineContext, ProgramMachineEvent, ProgramMachineState>({
+export const programMachine = Machine<ProgramMachineContext, ProgramMachineState, ProgramMachineEvent>({
   id: 'program',
   initial: ProgramState.UNKNOWN,
   states: {
@@ -227,6 +194,7 @@ export const programMachine = createMachine<ProgramMachineContext, ProgramMachin
   },
 
   on: {
+    [ProgramState.STARTING]: ProgramState.STARTING,
     [ProgramState.BACKOFF]: ProgramState.BACKOFF,
     [ProgramState.RUNNING]: ProgramState.RUNNING,
     [ProgramState.STOPPING]: ProgramState.STOPPING,

--- a/src/pages/programs/[id].vue
+++ b/src/pages/programs/[id].vue
@@ -182,6 +182,7 @@ import ChartBarIcon from '/@vite-icons/heroicons-outline/chart-bar.vue'
 import ChipIcon from '/@vite-icons/heroicons-outline/chip.vue'
 import IdentificationIcon from '/@vite-icons/heroicons-outline/identification.vue'
 
+import { restartProgram, startProgram, stopProgram } from '/~/api/program'
 import { useProgram } from '/~/composables/programs'
 import { programMachine, ProgramMachineActions, ProgramMachineMeta } from '/~/machines/program'
 import { mergeMeta } from '/~/machines/utils'
@@ -211,10 +212,10 @@ export default defineComponent({
     })
     const { state, send } = useMachine(programMachine, {
       actions: {
-        [ProgramMachineActions.START]: startProgram,
-        [ProgramMachineActions.STOP]: stopProgram,
-        [ProgramMachineActions.RESTART]: restartProgram,
-        [ProgramMachineActions.MODIFY]: modifyProgram,
+        [ProgramMachineActions.START]: handleStartProgram,
+        [ProgramMachineActions.STOP]: handleStopProgram,
+        [ProgramMachineActions.RESTART]: handleRestartProgram,
+        [ProgramMachineActions.MODIFY]: handleModifyProgram,
       },
     })
 
@@ -239,20 +240,55 @@ export default defineComponent({
       }))
     })
 
-    function startProgram() {
-      console.log('start the program')
+    async function handleStartProgram() {
+      const programId = program.value?.id
+      if (programId === undefined)
+        return
+
+      try {
+        await startProgram(programId)
+      }
+      catch (err) {
+        console.error(err)
+        // trigger notification
+      }
     }
 
-    function stopProgram() {
-      console.log('stop the program')
+    async function handleStopProgram() {
+      const programId = program.value?.id
+      if (programId === undefined)
+        return
+
+      try {
+        await stopProgram(programId)
+      }
+      catch (err) {
+        console.error(err)
+        // trigger notification
+      }
     }
 
-    function restartProgram() {
-      console.log('restart the program')
+    async function handleRestartProgram() {
+      const programId = program.value?.id
+      if (programId === undefined)
+        return
+
+      try {
+        await restartProgram(programId)
+      }
+      catch (err) {
+        console.error(err)
+        // trigger notification
+      }
     }
 
-    function modifyProgram() {
-      console.log('modify the program')
+    function handleModifyProgram() {
+      const programId = program.value?.id
+      if (programId === undefined)
+        return
+
+      // redirect to page to modify program configuration
+      console.log('update configuration')
     }
 
     const statistics = computed(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,3 +119,17 @@ export interface StartProgramResponse extends ResponseWithError {
 export function isStartProgramResponse(input: unknown): input is StartProgramResponse {
   return isResponseWithError(input)
 }
+
+export interface StopProgramResponse extends ResponseWithError {
+}
+
+export function isStopProgramResponse(input: unknown): input is StopProgramResponse {
+  return isResponseWithError(input)
+}
+
+export interface RestartProgramResponse extends ResponseWithError {
+}
+
+export function isRestartProgramResponse(input: unknown): input is RestartProgramResponse {
+  return isResponseWithError(input)
+}


### PR DESCRIPTION
We use [redaxios](https://github.com/developit/redaxios) to make API calls.

API responses are type asserted using type guards.

We make start/stop and restart requests when the corresponding buttons are clicked on a program page.
