### PR TITLE
Replace activeClass with exactActiveClass for link to home page

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -7,7 +7,11 @@
         </div>
         <div class="p-3">
           <div v-for="link in links" :key="link.title">
-            <router-link :to="link.url" active-class="bg-gray-100" class="block py-2.5 pl-5 my-1 rounded-lg sidebar-link hover:bg-gray-100 text-gray-700 font-semibold">
+            <router-link
+              :to="link.url"
+              v-bind="link.url === '/' ? { exactActiveClass:'bg-gray-100' } : { activeClass:'bg-gray-100' }"
+              class="block py-2.5 pl-5 my-1 rounded-lg sidebar-link hover:bg-gray-100 text-gray-700 font-semibold"
+            >
               <div class="flex items-center e">
                 <component :is="link.icon" class="text-lg" />
                 <div class="ml-4">


### PR DESCRIPTION
We use a `v-bind` to conditionally apply  `exactActiveClass` or `activeClass` prop.