### PR TITLE
Fix configuration and logs empty screen on second visit

### DIFF
--- a/src/pages/configuration/index.vue
+++ b/src/pages/configuration/index.vue
@@ -101,6 +101,8 @@ export default defineComponent({
       if (configuration === undefined)
         return
       configurationText.value = configuration
+    }, {
+      immediate: true,
     })
 
     const editorReadOnly = ref<boolean>(true)

--- a/src/pages/logs.vue
+++ b/src/pages/logs.vue
@@ -77,6 +77,8 @@ export default defineComponent({
 
       if (logsPre.value && wasAtBottomScroll)
         logsPre.value.scrollTop = logsPre.value.scrollHeight
+    }, {
+      immediate: true,
     })
     async function clearLogs() {
       if (!confirm(t('confirm_clear')))


### PR DESCRIPTION
After the first page visit, the useSWRV cache is already fulfilled, so watcher callback is not called.
We must always try to call it when the component is created.

Closes #23 