### PR TITLE
Use correct event name in the state machine

### DIFF
--- a/src/machines/program.ts
+++ b/src/machines/program.ts
@@ -122,7 +122,7 @@ export const programMachine = Machine<ProgramMachineContext, ProgramMachineState
         [AvailableAction.start]: {
           actions: ProgramMachineActions.START,
         },
-        [AvailableAction.EDIT]: {
+        [AvailableAction.edit]: {
           actions: ProgramMachineActions.EDIT,
         },
       },


### PR DESCRIPTION
During a refactor an event has not been renamed correctly.
Currently we can not edit a program when it's in stopped state.