### PR TITLE
Refresh logs

### DIFF
--- a/src/composables/logs.ts
+++ b/src/composables/logs.ts
@@ -12,6 +12,8 @@ export function useLogs() {
       throw new Error('Invalid fetcher')
 
     return await getLogs(fetcher.value.fetcher)
+  }, {
+    refreshInterval: 1_000,
   })
 
   const logs = computed<string | undefined>(() => {


### PR DESCRIPTION
We may refresh logs automatically, otherwise the `/logs` page has no real added value.