### PR TITLE
Use menu in small device to present header actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preview:simple": "vite preview"
   },
   "dependencies": {
+    "@headlessui/vue": "^0.3.0",
     "@tailwindcss/forms": "^0.2.1",
     "@vueuse/core": "^4.2.2",
     "@vueuse/head": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,5 @@
 dependencies:
+  '@headlessui/vue': 0.3.0_vue@3.0.5
   '@tailwindcss/forms': 0.2.1
   '@vueuse/core': 4.2.2_vue@3.0.5
   '@vueuse/head': 0.2.3_vue@3.0.5
@@ -1263,6 +1264,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
+  /@headlessui/vue/0.3.0_vue@3.0.5:
+    dependencies:
+      vue: 3.0.5
+    dev: false
+    engines:
+      node: '>=10'
+    peerDependencies:
+      vue: ^3.0.0-rc.13
+    resolution:
+      integrity: sha512-sNyfy1YTRTcertrsK14ZekEoIddbDxipoUw/VyO5DPGtHGo1kuozbSYi2WlU3MccDOwCv5pQc41koh4+bcnkmQ==
   /@iconify/json-tools/1.0.10:
     dev: true
     resolution:
@@ -1393,7 +1404,7 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
       '@nodelib/fs.walk': 1.2.6
-      glob-parent: 5.1.1
+      glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.2
       picomatch: 2.2.2
@@ -3510,6 +3521,14 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  /glob-parent/5.1.2:
+    dependencies:
+      is-glob: 4.0.1
+    dev: true
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   /glob-to-regexp/0.4.1:
     dev: true
     resolution:
@@ -6833,6 +6852,7 @@ specifiers:
   '@antfu/eslint-config': ^0.4.3
   '@commitlint/cli': ^11.0.0
   '@commitlint/config-conventional': ^11.0.0
+  '@headlessui/vue': ^0.3.0
   '@iconify/json': ^1.1.308
   '@intlify/vite-plugin-vue-i18n': ^1.0.0-beta.17
   '@tailwindcss/forms': ^0.2.1

--- a/src/components/AppButton.vue
+++ b/src/components/AppButton.vue
@@ -14,24 +14,9 @@
 
 <script lang="ts">
 import { defineComponent, computed, PropType } from 'vue'
+import { AppButtonColors, AppButtonSize, AppButtonStyle } from '/~/types/index'
 
-type Style = 'primary' | 'secondary' | 'outlined'
-
-enum Colors {
-  white = 'white',
-  red = 'red',
-  green = 'green',
-}
-
-type ColorClasses = Record<Colors, string>
-
-enum Size {
-  'x-small' = 'x-small',
-  'small' = 'small',
-  'base' = 'base',
-  'large' = 'large',
-  'x-large' = 'x-large',
-}
+type ColorClasses = Record<AppButtonColors, string>
 
 export default defineComponent({
   props: {
@@ -51,15 +36,15 @@ export default defineComponent({
     },
 
     color: {
-      type: String as PropType<Colors>,
-      default: Colors.white,
-      validator: (color: string): color is Colors => Reflect.has(Colors, color),
+      type: String as PropType<AppButtonColors>,
+      default: AppButtonColors.white,
+      validator: (color: string): color is AppButtonColors => Reflect.has(AppButtonColors, color),
     },
 
     size: {
-      type: String as PropType<Size>,
+      type: String as PropType<AppButtonSize>,
       default: 'base',
-      validator: (size: string): size is Size => Reflect.has(Size, size),
+      validator: (size: string): size is AppButtonSize => Reflect.has(AppButtonSize, size),
     },
 
     disabled: {
@@ -69,7 +54,7 @@ export default defineComponent({
   },
 
   setup(props) {
-    const buttonStyle = computed<Style>(() => {
+    const buttonStyle = computed<AppButtonStyle>(() => {
       switch (true) {
         case props.primary:
           return 'primary'
@@ -81,7 +66,7 @@ export default defineComponent({
     })
 
     const buttonStyleClasses = computed<ColorClasses>(() => {
-      const classes = new Map<Style, ColorClasses>([
+      const classes = new Map<AppButtonStyle, ColorClasses>([
         [
           'primary',
           {
@@ -116,25 +101,25 @@ export default defineComponent({
     })
 
     const sizeClasses = computed<string>(() => {
-      const classes = new Map<Size, string>([
+      const classes = new Map<AppButtonSize, string>([
         [
-          Size['x-small'],
+          AppButtonSize['x-small'],
           'px-2.5 py-1.5 text-xs font-medium',
         ],
         [
-          Size.small,
+          AppButtonSize.small,
           'px-3 py-2 text-sm leading-4 font-medium',
         ],
         [
-          Size.base,
+          AppButtonSize.base,
           'px-4 py-2 text-sm font-medium',
         ],
         [
-          Size.large,
+          AppButtonSize.large,
           'px-4 py-2 text-base font-medium',
         ],
         [
-          Size['x-large'],
+          AppButtonSize['x-large'],
           'px-6 py-3 text-base font-medium',
         ],
       ])
@@ -153,25 +138,25 @@ export default defineComponent({
     })
 
     const iconClasses = computed(() => {
-      const classes = new Map<Size, string>([
+      const classes = new Map<AppButtonSize, string>([
         [
-          Size['x-small'],
+          AppButtonSize['x-small'],
           '-ml-0.5 mr-2 h-4 w-4',
         ],
         [
-          Size.small,
+          AppButtonSize.small,
           '-ml-1 mr-2 h-5 w-5',
         ],
         [
-          Size.base,
+          AppButtonSize.base,
           '-ml-1 mr-2 h-5 w-5',
         ],
         [
-          Size.large,
+          AppButtonSize.large,
           '-ml-1 mr-3 h-5 w-5',
         ],
         [
-          Size['x-large'],
+          AppButtonSize['x-large'],
           '-ml-1 mr-3 h-5 w-5',
         ],
       ])

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -1,58 +1,31 @@
-<template>
-  <div class="flex flex-col w-full h-full min-h-screen">
-    <header class="flex items-stretch bg-white shadow">
-      <button class="px-8 text-gray-500 border-r border-gray-200 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 md:hidden" @click="toggleIsOpen">
-        <span class="sr-only">
-          {{ t('open-sidebar') }}
-        </span>
-        <!-- Heroicon name: outline/menu-alt-2 -->
-        <svg
-          class="w-6 h-6"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
-        </svg>
-      </button>
-
-      <div class="flex items-center justify-between flex-grow px-4 py-6 mx-auto max-w-7xl sm:px-6 lg:px-8">
-        <h1 class="text-2xl font-bold">
-          <slot name="title" />
-        </h1>
-
-        <div v-if="$slots['actions']" class="flex space-x-2">
-          <slot name="actions" />
-        </div>
-      </div>
-    </header>
-
-    <div
-      :class="[
-        'flex-grow w-full h-full',
-        {
-          'px-4 mx-auto my-8 max-w-7xl sm:px-6 lg:px-8': constraintWidth
-        }
-      ]"
-    >
-      <slot />
-    </div>
-  </div>
-</template>
-
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/vue'
 
 import { useSidebar } from '/~/composables/sidebar'
+import { ActionOptions, isActionOptions } from '/~/types/index'
 
 export default defineComponent({
+  components: {
+    Menu,
+    MenuButton,
+    MenuItems,
+    MenuItem,
+  },
+
   props: {
     constraintWidth: {
       type: Boolean,
       default: true,
+    },
+
+    actions: {
+      type: Array as PropType<ActionOptions[]>,
+      default: (): ActionOptions[] => [],
+      validator: (actions: unknown[]): actions is ActionOptions[] => {
+        return actions.every(isActionOptions)
+      },
     },
   },
 
@@ -70,14 +43,142 @@ export default defineComponent({
 })
 </script>
 
+<template>
+  <div class="flex flex-col w-full h-full min-h-screen">
+    <header class="flex items-stretch bg-white shadow">
+      <button class="px-4 text-gray-500 border-r border-gray-200 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 md:hidden" @click="toggleIsOpen">
+        <span class="sr-only">
+          {{ t('open-sidebar') }}
+        </span>
+        <!-- Heroicon name: outline/menu-alt-2 -->
+        <svg
+          class="w-6 h-6"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
+        </svg>
+      </button>
+
+      <div class="flex items-center justify-between flex-grow px-4 py-3 mx-auto sm:py-6 max-w-7xl sm:px-6 lg:px-8">
+        <h1 class="text-lg font-bold sm:text-2xl">
+          <slot name="title" />
+        </h1>
+
+        <div v-if="actions.length > 0" class="ml-2">
+          <div class="hidden space-x-2 sm:flex">
+            <AppButton
+              v-for="{text, icon, size, color, disabled, onClick} in actions"
+              :key="text"
+              :size="size"
+              :color="color"
+              :disabled="disabled"
+              @click="onClick"
+            >
+              <component :is="icon" v-if="icon !== undefined" class="mr-2" />
+
+              {{ text }}
+            </AppButton>
+          </div>
+
+          <div class="relative inline-block text-left sm:hidden">
+            <Menu>
+              <span class="rounded-md shadow-sm">
+                <MenuButton
+                  class="inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800"
+                >
+                  <span>
+                    {{ t('options') }}
+                  </span>
+
+                  <svg
+                    class="w-5 h-5 ml-2 -mr-1"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
+                </MenuButton>
+              </span>
+
+              <transition
+                enter-active-class="transition duration-100 ease-out"
+                enter-from-class="transform scale-95 opacity-0"
+                enter-to-class="transform scale-100 opacity-100"
+                leave-active-class="transition duration-75 ease-out"
+                leave-from-class="transform scale-100 opacity-100"
+                leave-to-class="transform scale-95 opacity-0"
+              >
+                <MenuItems
+                  class="absolute right-0 z-10 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
+                >
+                  <div class="py-1">
+                    <MenuItem
+                      v-for="{text, icon, disabled, onClick} in actions"
+                      :key="text"
+                      v-slot="{ active }"
+                      :disabled="disabled"
+                    >
+                      <button
+                        type="button"
+                        :class="[
+                          active ? 'text-gray-900 bg-gray-100' : 'text-gray-700',
+                          'flex items-center px-4 py-2 text-sm group w-full'
+                        ]"
+                        role="menuitem"
+                        @click="onClick"
+                      >
+                        <component
+                          :is="icon"
+                          v-if="icon !== undefined"
+                          :class="[
+                            active ? 'text-gray-500' : 'text-gray-400',
+                            'w-5 h-5 mr-3'
+                          ]"
+                        />
+
+                        {{ text }}
+                      </button>
+                    </MenuItem>
+                  </div>
+                </MenuItems>
+              </transition>
+            </Menu>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div
+      :class="[
+        'flex-grow w-full h-full',
+        {
+          'px-4 mx-auto my-8 max-w-7xl sm:px-6 lg:px-8': constraintWidth
+        }
+      ]"
+    >
+      <slot />
+    </div>
+  </div>
+</template>
+
 <i18n>
 {
   "en": {
     "open-sidebar": "Open sidebar",
+    "options": "Options",
   },
 
   "fr": {
     "open-sidebar": "Ouvrir le menu",
+    "options": "Options",
   }
 }
 </i18n>

--- a/src/components/TheSidebar.vue
+++ b/src/components/TheSidebar.vue
@@ -46,7 +46,7 @@
         >
           <div v-show="isOpen" class="relative flex flex-col flex-1 w-full max-w-xs">
             <div class="absolute top-0 right-0 pt-2 -mr-12">
-              <button class="flex items-center justify-center w-10 h-10 ml-1 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white" @click="closeSidebar">
+              <button v-show="isOpen" class="flex items-center justify-center w-10 h-10 ml-1 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white" @click="closeSidebar">
                 <span class="sr-only">
                   {{ t('close-sidebar') }}
                 </span>

--- a/src/pages/configuration/index.vue
+++ b/src/pages/configuration/index.vue
@@ -3,28 +3,9 @@
     <AppLoadingOverlay />
   </div>
 
-  <AppLayout>
+  <AppLayout :actions="layoutActions">
     <template #title>
       Configuration
-    </template>
-
-    <template #actions>
-      <AppButton v-if="!editing" @click="startEditing">
-        <heroicons-outline-pencil class="mr-2" />
-        {{ t('button.edit') }}
-      </AppButton>
-      <template
-        v-else
-      >
-        <AppButton color="green" outlined="false" class="mr-2" @click="saveEditing">
-          <heroicons-outline-save class="mr-2" />
-          {{ t('button.save') }}
-        </AppButton>
-        <AppButton color="red" @click="cancelEditing">
-          <heroicons-outline-x class="mr-2" />
-          {{ t('button.cancel') }}
-        </AppButton>
-      </template>
     </template>
 
     <div class="flex flex-col h-full">
@@ -65,15 +46,18 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, watch, ref } from 'vue'
+import { defineComponent, watch, ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { VAceEditor } from 'vue3-ace-editor'
 import 'ace-builds/src-noconflict/mode-yaml'
 import 'ace-builds/src-noconflict/theme-chrome'
+import SaveIcon from '/@vite-icons/heroicons-outline/save.vue'
+import XIcon from '/@vite-icons/heroicons-outline/x.vue'
+import PencilIcon from '/@vite-icons/heroicons-outline/pencil.vue'
 
 import { putConfiguration } from '/~/api/configuration'
 import { useConfiguration } from '/~/composables/configuration'
-import { useI18n } from 'vue-i18n'
-import { Alert, AlertType } from '/~/types/index'
+import { Alert, AlertType, ActionOptions, AppButtonColors } from '/~/types/index'
 import { useFetcher } from '/~/composables/fetcher'
 
 export default defineComponent({
@@ -146,6 +130,27 @@ export default defineComponent({
       }
     }
 
+    const layoutActions = computed<ActionOptions[]>(() => editing.value === true ? [
+      {
+        color: AppButtonColors.green,
+        icon: SaveIcon,
+        text: t('button.save'),
+        onClick: saveEditing,
+      },
+      {
+        color: AppButtonColors.red,
+        icon: XIcon,
+        text: t('button.cancel'),
+        onClick: cancelEditing,
+      },
+    ] : [
+      {
+        icon: PencilIcon,
+        text: t('button.edit'),
+        onClick: startEditing,
+      },
+    ])
+
     return {
       t,
 
@@ -163,6 +168,7 @@ export default defineComponent({
       cancelEditing,
       saveEditing,
 
+      layoutActions,
     }
   },
 })

--- a/src/pages/logs.vue
+++ b/src/pages/logs.vue
@@ -3,16 +3,9 @@
     <AppLoadingOverlay />
   </div>
 
-  <AppLayout>
+  <AppLayout :actions="layoutActions">
     <template #title>
       Logs
-    </template>
-
-    <template #actions>
-      <AppButton color="red" @click="clearLogs">
-        <heroicons-outline-trash class="mr-2" />
-        {{ t('clear') }}
-      </AppButton>
     </template>
 
     <div class="flex flex-col h-full">
@@ -32,13 +25,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, watch, ref, nextTick } from 'vue'
+import { defineComponent, watch, ref, nextTick, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import TrashIcon from '/@vite-icons/heroicons-outline/trash.vue'
 
 import { useLogs } from '/~/composables/logs'
-import { useI18n } from 'vue-i18n'
-import { deleteLogs } from '../api/logs'
-import { Alert, AlertType } from '../types/index'
-import { useFetcher } from '../composables/fetcher'
+import { deleteLogs } from '/~/api/logs'
+import { Alert, AlertType, ActionOptions, AppButtonColors } from '/~/types/index'
+import { useFetcher } from '/~/composables/fetcher'
 
 export default defineComponent({
   setup() {
@@ -99,6 +93,15 @@ export default defineComponent({
       }
     }
 
+    const layoutActions = computed<ActionOptions[]>(() => [
+      {
+        color: AppButtonColors.red,
+        icon: TrashIcon,
+        text: t('clear'),
+        onClick: clearLogs,
+      },
+    ])
+
     return {
       t,
 
@@ -110,6 +113,8 @@ export default defineComponent({
       logsPre,
       logsText,
       clearLogs,
+
+      layoutActions,
     }
   },
 })

--- a/src/pages/new.vue
+++ b/src/pages/new.vue
@@ -1,17 +1,10 @@
 <template>
-  <AppLayout>
+  <AppLayout :actions="layoutActions">
     <template #title>
       <router-link to="/programs" :title="t('button.back')">
-        <heroicons-outline-arrow-left class="inline mr-4 text-2xl text-gray-500 hover:text-gray-700" />
+        <heroicons-outline-arrow-left class="inline mr-4 text-gray-500 hover:text-gray-700" />
       </router-link>
       {{ t('add_new_program') }}
-    </template>
-
-    <template #actions>
-      <AppButton size="large" color="green" @click="saveProgram">
-        <heroicons-outline-plus-circle class="mr-2" />
-        {{ t('button.save') }}
-      </AppButton>
     </template>
 
     <AppAlert v-if="alert.show" :type="alert.type" :close-callback="closeAlert">
@@ -25,11 +18,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue'
+import { computed, defineComponent, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { Alert, AlertType, ProgramConfiguration } from '../types/index'
-import { useFetcher } from '../composables/fetcher'
+import PlusCircleIcon from '/@vite-icons/heroicons-outline/plus-circle.vue'
+
+import { Alert, AlertType, ProgramConfiguration, ActionOptions, AppButtonColors, AppButtonSize } from '/~/types/index'
+import { useFetcher } from '/~/composables/fetcher'
 
 export default defineComponent({
   setup() {
@@ -78,6 +73,16 @@ export default defineComponent({
       }
     }
 
+    const layoutActions = computed<ActionOptions[]>(() => [
+      {
+        size: AppButtonSize.large,
+        color: AppButtonColors.green,
+        icon: PlusCircleIcon,
+        text: t('button.save'),
+        onClick: saveProgram,
+      },
+    ])
+
     return {
       t,
 
@@ -87,6 +92,8 @@ export default defineComponent({
       closeAlert,
 
       saveProgram,
+
+      layoutActions,
     }
   },
 })

--- a/src/pages/programs/[id]/edit.vue
+++ b/src/pages/programs/[id]/edit.vue
@@ -8,23 +8,12 @@
       {{ t('program_unknown') }}
     </AppAlert>
 
-    <AppLayout v-else>
+    <AppLayout v-else :actions="layoutActions">
       <template #title>
         <router-link :to="programUrl" :title="t('button.back')">
-          <heroicons-outline-arrow-left class="inline mr-4 text-2xl text-gray-500 hover:text-gray-700" />
+          <heroicons-outline-arrow-left class="inline mr-4 text-gray-500 hover:text-gray-700" />
         </router-link>
         {{ t('editing') }} {{ program.id }}
-      </template>
-
-      <template #actions>
-        <AppButton size="large" color="green" @click="saveProgram">
-          <heroicons-outline-save class="mr-2" />
-          {{ t('save') }}
-        </AppButton>
-        <AppButton size="large" color="red" @click="deleteProgram">
-          <heroicons-outline-trash class="mr-2" />
-          {{ t('delete') }}
-        </AppButton>
       </template>
 
       <AppAlert v-if="alert.show" :type="alert.type" :close-callback="closeAlert">
@@ -40,10 +29,12 @@
 import { defineComponent, computed, capitalize, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { useFetcher } from '/~/composables/fetcher'
+import SaveIcon from '/@vite-icons/heroicons-outline/save.vue'
+import TrashIcon from '/@vite-icons/heroicons-outline/trash.vue'
 
+import { useFetcher } from '/~/composables/fetcher'
 import { useProgram } from '/~/composables/programs'
-import { Alert, AlertType, ProgramConfiguration } from '/~/types/index'
+import { Alert, AlertType, ProgramConfiguration, ActionOptions, AppButtonColors } from '/~/types/index'
 
 export default defineComponent({
   props: {
@@ -123,17 +114,37 @@ export default defineComponent({
       }
     }
 
+    const layoutActions = computed<ActionOptions[]>(() => [
+      {
+        color: AppButtonColors.green,
+        icon: SaveIcon,
+        text: t('save'),
+        onClick: saveProgram,
+      },
+      {
+        color: AppButtonColors.red,
+        icon: TrashIcon,
+        text: t('delete'),
+        onClick: deleteProgram,
+      },
+    ])
+
     return {
       t,
+
       alert,
       closeAlert,
+
       configuration,
+
       program,
       programTitle,
       programUrl,
       isLoading,
       saveProgram,
       deleteProgram,
+
+      layoutActions,
     }
   },
 })

--- a/src/pages/programs/[id]/index.vue
+++ b/src/pages/programs/[id]/index.vue
@@ -8,18 +8,12 @@
       {{ t('program_unknown') }}
     </AppAlert>
 
-    <AppLayout v-else>
+    <AppLayout v-else :actions="layoutActions">
       <template #title>
         <router-link to="/programs" :title="t('button.back')">
-          <heroicons-outline-arrow-left class="inline mr-4 text-2xl text-gray-500 hover:text-gray-700" />
+          <heroicons-outline-arrow-left class="inline mr-4 text-gray-500 hover:text-gray-700" />
         </router-link>
         {{ programTitle }}
-      </template>
-
-      <template #actions>
-        <AppButton v-for="{text, action} in actions" :key="text" size="large" @click="action">
-          {{ text }}
-        </AppButton>
       </template>
 
       <AppAlert v-if="alert.show" :type="alert.type" :close-callback="closeAlert">
@@ -188,7 +182,7 @@ import { restartProgram, startProgram, stopProgram } from '/~/api/program'
 import { useProgram } from '/~/composables/programs'
 import { programMachine, ProgramMachineActions, ProgramMachineMeta } from '/~/machines/program'
 import { mergeMeta } from '/~/machines/utils'
-import { Alert, AlertType, Program } from '/~/types/index'
+import { Alert, AlertType, Program, ActionOptions, AppButtonSize } from '/~/types/index'
 import { useRouter } from 'vue-router'
 import { useFetcher } from '/~/composables/fetcher'
 
@@ -250,13 +244,14 @@ export default defineComponent({
       immediate: true,
     })
 
-    const actions = computed(() => {
+    const layoutActions = computed<ActionOptions[]>(() => {
       const currentStateMeta = state.value.meta
       const { actions } = mergeMeta<ProgramMachineMeta>(currentStateMeta)
 
       return actions.map(action => ({
+        size: AppButtonSize.large,
         text: t(`button.${action}`),
-        action: () => send(action),
+        onClick: () => send(action),
       }))
     })
 
@@ -343,7 +338,6 @@ export default defineComponent({
         },
         {
           text: t('command'),
-          // FIXME: replace with the real command
           value: program.value.configuration.cmd,
           icon: IdentificationIcon,
         },
@@ -408,7 +402,7 @@ export default defineComponent({
       programTitle,
       isLoading,
 
-      actions,
+      layoutActions,
 
       statistics,
       processes,

--- a/src/pages/programs/index.vue
+++ b/src/pages/programs/index.vue
@@ -3,20 +3,9 @@
     <AppLoadingOverlay />
   </div>
 
-  <AppLayout>
+  <AppLayout :actions="layoutActions">
     <template #title>
       {{ t('programs') }}
-    </template>
-
-    <template #actions>
-      <AppButton :color="allProgramsAreStopped ? 'green' : 'white'" @click="startPrograms">
-        <heroicons-outline-arrow-circle-up class="mr-1" />
-        {{ allProgramsAreStopped ? t('start_all') : t('restart_all') }}
-      </AppButton>
-      <AppButton color="red" :disabled="allProgramsAreStopped" @click="stopPrograms">
-        <heroicons-outline-x-circle class="mr-1" />
-        {{ t('stop_all') }}
-      </AppButton>
     </template>
 
     <AppAlert v-if="alert.show" :type="alert.type" :close-callback="closeAlert">
@@ -82,15 +71,18 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, computed } from 'vue'
-import { usePrograms } from '/~/composables/programs'
+import { defineComponent, ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import ViewGridIcon from '/@vite-icons/heroicons-outline/view-grid.vue'
 import MenuIcon from '/@vite-icons/heroicons-outline/menu.vue'
-import { Alert, AlertType } from '/~/types/index'
+import ArrowCircleUpIcon from '/@vite-icons/heroicons-outline/arrow-circle-up.vue'
+import XCircleIcon from '/@vite-icons/heroicons-outline/x-circle.vue'
 
-import { useRouter } from 'vue-router'
+import { usePrograms } from '/~/composables/programs'
 import { useFetcher } from '/~/composables/fetcher'
+import { ActionOptions, Alert, AlertType, AppButtonColors } from '/~/types/index'
+
 export default defineComponent({
   components: {
     ViewGridIcon,
@@ -176,6 +168,22 @@ export default defineComponent({
       }
     }
 
+    const layoutActions = computed<ActionOptions[]>(() => [
+      {
+        color: allProgramsAreStopped.value === true ? AppButtonColors.green : AppButtonColors.white,
+        icon: ArrowCircleUpIcon,
+        text: allProgramsAreStopped.value ? t('start_all') : t('restart_all'),
+        onClick: startPrograms,
+      },
+      {
+        color: AppButtonColors.red,
+        icon: XCircleIcon,
+        text: t('stop_all'),
+        disabled: allProgramsAreStopped.value,
+        onClick: stopPrograms,
+      },
+    ])
+
     return {
       t,
 
@@ -196,6 +204,8 @@ export default defineComponent({
       startPrograms,
       stopPrograms,
       restartPrograms,
+
+      layoutActions,
     }
   },
 })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,3 +196,36 @@ export function isKeyValueObject(input: unknown): input is KeyValueObject {
     && Reflect.has(input as KeyValueObject, 'value')
   )
 }
+
+export type AppButtonStyle = 'primary' | 'secondary' | 'outlined'
+
+export enum AppButtonColors {
+  white = 'white',
+  red = 'red',
+  green = 'green',
+}
+
+export enum AppButtonSize {
+  'x-small' = 'x-small',
+  'small' = 'small',
+  'base' = 'base',
+  'large' = 'large',
+  'x-large' = 'x-large',
+}
+
+export interface ActionOptions {
+  text: string
+  icon?: string
+  size?: AppButtonSize
+  color?: AppButtonColors
+  disabled?: boolean
+  onClick: () => void
+}
+
+export function isActionOptions(input: unknown): input is ActionOptions {
+  return (
+    typeof input === 'object'
+    && input !== null
+    && typeof (input as ActionOptions).text === 'string'
+  )
+}


### PR DESCRIPTION
We had to find a way to present header actions on small devices.
We used a menu as it's simple to use and simple to code.